### PR TITLE
Control state-of-charge indicator

### DIFF
--- a/BatterySpoof/BatterySpoof.ino
+++ b/BatterySpoof/BatterySpoof.ino
@@ -1,3 +1,4 @@
+#include "gauge.hpp"
 #include "spoof.hpp"
 #if INTERACTIVE
 #include "interactive.hpp"
@@ -9,11 +10,17 @@ void setup() {
 #if DEBUG_LOG || INTERACTIVE
   Serial.begin(9600);
 #endif
+
+  set_gauge_soc(0);
 }
 
 void loop() {
   if (Serial1.available() >= 2) {
     car_request();
+  }
+  int soc;
+  if ((soc = try_read_soc()) != -1) {
+    set_gauge_soc(soc);
   }
 #if INTERACTIVE
   else if (Serial.available() != 0) {
@@ -72,6 +79,12 @@ int read_serial1() {
   Serial.println(b, HEX);
 #endif
   return b;
+}
+
+// Read the state of charge, if it's available. -1 means nothing was read
+int try_read_soc() {
+  // TODO: read from CAN bus
+  return -1;
 }
 
 #if INTERACTIVE

--- a/BatterySpoof/gauge.cpp
+++ b/BatterySpoof/gauge.cpp
@@ -1,0 +1,9 @@
+#include "gauge.hpp"
+
+analogWave wave(DAC);
+
+void set_gauge_soc(int soc) {
+  // ~47 Hz is the bottom of the SoC gauge, and 150 Hz is the top
+  float freq = 47 + (1.03 * soc);
+  wave.square(round(freq));
+}

--- a/BatterySpoof/gauge.hpp
+++ b/BatterySpoof/gauge.hpp
@@ -1,0 +1,8 @@
+#ifndef RAV4_GAUGE_HPP
+#define RAV4_GAUGE_HPP
+
+#include "analogWave.h"
+
+void set_gauge_soc(int soc);
+
+#endif

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifdef INTERACTIVE
 	extra_compilation_flags += -DINTERACTIVE
 endif
 
-BatterySpoof/build/$(fqbn_path)/BatterySpoof.ino.elf: BatterySpoof/BatterySpoof.ino BatterySpoof/spoof.hpp BatterySpoof/spoof.cpp BatterySpoof/interactive.hpp BatterySpoof/interactive.cpp
+BatterySpoof/build/$(fqbn_path)/BatterySpoof.ino.elf: BatterySpoof/BatterySpoof.ino BatterySpoof/spoof.hpp BatterySpoof/spoof.cpp BatterySpoof/interactive.hpp BatterySpoof/interactive.cpp BatterySpoof/gauge.hpp BatterySpoof/gauge.cpp
 	arduino-cli compile --fqbn $(fqbn) BatterySpoof --export-binaries --warnings all \
 		--build-property compiler.cpp.extra_flags="$(extra_compilation_flags)"
 


### PR DESCRIPTION
The RAV4 EV state-of-charge indicator accepts a square wave whose frequency specifies the current SoC. It's mapped from 40 Hz at the bottom to 150 Hz at the top, but the bottom 7% or so is below where the actual markings on the dashboard begin. I'm choosing to map 47 Hz (about 7% on the dial) to 0% SoC, and use the range from 47 Hz to 150 Hz.

Actually reading the state of charge from the Orion battery management system will come later. Right now that's a function that's effectively just stubbed out.