### PR TITLE
Read state of charge from CAN bus

### DIFF
--- a/BatterySpoof/BatterySpoof.ino
+++ b/BatterySpoof/BatterySpoof.ino
@@ -1,3 +1,4 @@
+#include "can.hpp"
 #include "gauge.hpp"
 #include "spoof.hpp"
 #if INTERACTIVE
@@ -12,14 +13,15 @@ void setup() {
 #endif
 
   set_gauge_soc(0);
+  init_can();
 }
 
 void loop() {
   if (Serial1.available() >= 2) {
     car_request();
   }
-  int soc;
-  if ((soc = try_read_soc()) != -1) {
+  float soc;
+  if ((soc = read_soc()) != -1) {
     set_gauge_soc(soc);
   }
 #if INTERACTIVE
@@ -79,12 +81,6 @@ int read_serial1() {
   Serial.println(b, HEX);
 #endif
   return b;
-}
-
-// Read the state of charge, if it's available. -1 means nothing was read
-int try_read_soc() {
-  // TODO: read from CAN bus
-  return -1;
 }
 
 #if INTERACTIVE

--- a/BatterySpoof/can.cpp
+++ b/BatterySpoof/can.cpp
@@ -1,0 +1,45 @@
+#include "can.hpp"
+
+bool can_initialized = false;
+
+void init_can() {
+  for (unsigned int mailbox = 0;
+       mailbox < R7FA4M1_CAN::CAN_MAX_NO_STANDARD_MAILBOXES; mailbox++) {
+    CAN.setFilterId_Standard(mailbox, 0x6b0);
+  }
+
+  can_initialized = CAN.begin(CanBitRate::BR_250k);
+  if (!can_initialized) {
+#if DEBUG_LOG
+    Serial.println("Failed to initialize CAN.");
+#endif
+  }
+}
+
+// Reads the state-of-charge (SoC) from the CAN bus.
+// Returns a float representing the SoC as a percentage (0.5% resolution).
+// Returns -1 if no SoC message was available to read, if CAN was
+// not initialized, or if there was an error condition.
+float read_soc() {
+  if (!can_initialized) {
+    return -1;
+  }
+  if (!CAN.available()) {
+    return -1;
+  }
+  CanMsg const msg = CAN.read();
+  // msg.id is 0x6b0, due to filtering
+#if DEBUG_LOG
+  // TODO: verify that msg.is is always 0x6b0
+  Serial.print("Read message from CAN with ID: ");
+  Serial.println(msg.id);
+#endif
+  if (msg.data_length < 5) {
+    return -1;
+  }
+#if DEBUG_LOG
+  Serial.print("Read SoC from CAN bus: ");
+  Serial.println(msg.data[4] / 2.0);
+#endif
+  return msg.data[4] / 2.0;
+}

--- a/BatterySpoof/can.hpp
+++ b/BatterySpoof/can.hpp
@@ -1,0 +1,9 @@
+#ifndef RAV4_CAN_HPP
+#define RAV4_CAN_HPP
+
+#include <Arduino_CAN.h>
+
+void init_can();
+float read_soc();
+
+#endif

--- a/BatterySpoof/gauge.cpp
+++ b/BatterySpoof/gauge.cpp
@@ -2,7 +2,7 @@
 
 analogWave wave(DAC);
 
-void set_gauge_soc(int soc) {
+void set_gauge_soc(float soc) {
   // ~47 Hz is the bottom of the SoC gauge, and 150 Hz is the top
   float freq = 47 + (1.03 * soc);
   wave.square(round(freq));

--- a/BatterySpoof/gauge.hpp
+++ b/BatterySpoof/gauge.hpp
@@ -3,6 +3,6 @@
 
 #include "analogWave.h"
 
-void set_gauge_soc(int soc);
+void set_gauge_soc(float soc);
 
 #endif

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifdef INTERACTIVE
 	extra_compilation_flags += -DINTERACTIVE
 endif
 
-BatterySpoof/build/$(fqbn_path)/BatterySpoof.ino.elf: BatterySpoof/BatterySpoof.ino BatterySpoof/spoof.hpp BatterySpoof/spoof.cpp BatterySpoof/interactive.hpp BatterySpoof/interactive.cpp BatterySpoof/gauge.hpp BatterySpoof/gauge.cpp
+BatterySpoof/build/$(fqbn_path)/BatterySpoof.ino.elf: BatterySpoof/BatterySpoof.ino BatterySpoof/spoof.hpp BatterySpoof/spoof.cpp BatterySpoof/interactive.hpp BatterySpoof/interactive.cpp BatterySpoof/gauge.hpp BatterySpoof/gauge.cpp BatterySpoof/can.hpp BatterySpoof/can.cpp
 	arduino-cli compile --fqbn $(fqbn) BatterySpoof --export-binaries --warnings all \
 		--build-property compiler.cpp.extra_flags="$(extra_compilation_flags)"
 


### PR DESCRIPTION
This adds the much-awaited functionality to read messages on the CAN bus. We're configuring our Orion to send state-of-charge as byte 4 of a message with ID 0x6b0. It sends it as twice-SoC percentage (as an int).

I still need to confirm on the actual hardware that this properly filters only packets with a specific ID. If it doesn't, I can mess with the filters and/or add a software-level check.