### PR TITLE
Report high voltage at ≥90% SoC

### DIFF
--- a/BatterySpoof/BatterySpoof.ino
+++ b/BatterySpoof/BatterySpoof.ino
@@ -1,17 +1,22 @@
 #include "can.hpp"
 #include "gauge.hpp"
 #include "spoof.hpp"
+#include "time.hpp"
 
 unsigned char HEALTHY_PACKET[PACKET_LEN];
 unsigned char HIGH_VOLTAGE_PACKET[PACKET_LEN];
 
 bool high_soc = false;
+unsigned long soc_last_read;
+constexpr unsigned long SOC_VALIDITY_MILLIS = 5000;
 
 void setup() {
   Serial1.begin(2400, SERIAL_8N1);
   init_packet(HEALTHY_PACKET);
   init_packet(HIGH_VOLTAGE_PACKET);
   set_voltage(HIGH_VOLTAGE_PACKET, 14.5);
+  soc_last_read = millis();
+
 #if DEBUG_LOG
   Serial.begin(9600);
 #endif
@@ -28,6 +33,7 @@ void loop() {
   if ((soc = read_soc()) != -1) {
     set_gauge_soc(soc);
     high_soc = (soc >= 90.0);
+    soc_last_read = millis();
   }
 }
 
@@ -63,7 +69,7 @@ void car_request() {
     return;
   }
 
-  if (high_soc) {
+  if (!soc_is_recent() || high_soc) {
     Serial1.write(HIGH_VOLTAGE_PACKET, PACKET_LEN);
   } else {
     Serial1.write(HEALTHY_PACKET, PACKET_LEN);
@@ -83,4 +89,9 @@ int read_serial1() {
   Serial.println(b, HEX);
 #endif
   return b;
+}
+
+bool soc_is_recent() {
+  const unsigned long now = millis();
+  return time_between(soc_last_read, now) < SOC_VALIDITY_MILLIS;
 }

--- a/BatterySpoof/BatterySpoof.ino
+++ b/BatterySpoof/BatterySpoof.ino
@@ -2,9 +2,11 @@
 #include "gauge.hpp"
 #include "spoof.hpp"
 
+unsigned char HEALTHY_PACKET[PACKET_LEN];
+
 void setup() {
   Serial1.begin(2400, SERIAL_8N1);
-  init_packet();
+  init_packet(HEALTHY_PACKET);
 #if DEBUG_LOG
   Serial.begin(9600);
 #endif
@@ -55,13 +57,11 @@ void car_request() {
     return;
   }
 
-  unsigned char *packet;
-  int packet_len = healthy_packet(&packet);
-  Serial1.write(packet, packet_len);
+  Serial1.write(HEALTHY_PACKET, PACKET_LEN);
 
 #if DEBUG_LOG
   Serial.print("wrote ");
-  Serial.print(packet_len);
+  Serial.print(PACKET_LEN);
   Serial.println(" bytes");
 #endif
 }

--- a/BatterySpoof/BatterySpoof.ino
+++ b/BatterySpoof/BatterySpoof.ino
@@ -3,10 +3,15 @@
 #include "spoof.hpp"
 
 unsigned char HEALTHY_PACKET[PACKET_LEN];
+unsigned char HIGH_VOLTAGE_PACKET[PACKET_LEN];
+
+bool high_soc = false;
 
 void setup() {
   Serial1.begin(2400, SERIAL_8N1);
   init_packet(HEALTHY_PACKET);
+  init_packet(HIGH_VOLTAGE_PACKET);
+  set_voltage(HIGH_VOLTAGE_PACKET, 14.5);
 #if DEBUG_LOG
   Serial.begin(9600);
 #endif
@@ -22,6 +27,7 @@ void loop() {
   float soc;
   if ((soc = read_soc()) != -1) {
     set_gauge_soc(soc);
+    high_soc = (soc >= 90.0);
   }
 }
 
@@ -57,7 +63,11 @@ void car_request() {
     return;
   }
 
-  Serial1.write(HEALTHY_PACKET, PACKET_LEN);
+  if (high_soc) {
+    Serial1.write(HIGH_VOLTAGE_PACKET, PACKET_LEN);
+  } else {
+    Serial1.write(HEALTHY_PACKET, PACKET_LEN);
+  }
 
 #if DEBUG_LOG
   Serial.print("wrote ");

--- a/BatterySpoof/BatterySpoof.ino
+++ b/BatterySpoof/BatterySpoof.ino
@@ -71,6 +71,9 @@ void car_request() {
 
   if (!soc_is_recent() || high_soc) {
     Serial1.write(HIGH_VOLTAGE_PACKET, PACKET_LEN);
+#if DEBUG_LOG
+    Serial.println("Reporting high cell voltage");
+#endif
   } else {
     Serial1.write(HEALTHY_PACKET, PACKET_LEN);
   }
@@ -93,5 +96,11 @@ int read_serial1() {
 
 bool soc_is_recent() {
   const unsigned long now = millis();
-  return time_between(soc_last_read, now) < SOC_VALIDITY_MILLIS;
+  const bool result = time_between(soc_last_read, now) < SOC_VALIDITY_MILLIS;
+#if DEBUG_LOG
+  if (!result) {
+    Serial.println("SoC value is not recent!")
+  }
+#endif
+  return result;
 }

--- a/BatterySpoof/spoof.cpp
+++ b/BatterySpoof/spoof.cpp
@@ -1,8 +1,5 @@
 #include "spoof.hpp"
 
-constexpr int PACKET_LEN = 62;
-unsigned char HEALTHY_PACKET[PACKET_LEN];
-
 unsigned char checksum(const unsigned char *arr, const int len) {
   unsigned char out = 0;
   for (int i = 0; i < len; i++) {
@@ -11,69 +8,68 @@ unsigned char checksum(const unsigned char *arr, const int len) {
   return out;
 }
 
-void init_packet() {
+void init_packet(unsigned char *packet) {
   int i = 0;
-  HEALTHY_PACKET[i++] = 255;            // header
-  HEALTHY_PACKET[i++] = PACKET_LEN - 2; // header: length
-  HEALTHY_PACKET[i++] = 49;             // header: unknown
+  packet[i++] = 255;            // header
+  packet[i++] = PACKET_LEN - 2; // header: length
+  packet[i++] = 49;             // header: unknown
   for (int j = 0; j < 24; j++) {
     // voltage: 12.8 V
-    HEALTHY_PACKET[i++] = 0;  // low byte
-    HEALTHY_PACKET[i++] = 50; // high byte
+    packet[i++] = 0;  // low byte
+    packet[i++] = 50; // high byte
   }
   for (int j = 0; j < 4; j++) {
     // temperature: 72 F (22.222 Celsius)
-    HEALTHY_PACKET[i++] = 206; // low byte
-    HEALTHY_PACKET[i++] = 86;  // high byte
+    packet[i++] = 206; // low byte
+    packet[i++] = 86;  // high byte
   }
-  HEALTHY_PACKET[i++] = 0; // padding to reach full length?
-  HEALTHY_PACKET[i++] = 0;
+  packet[i++] = 0; // padding to reach full length?
+  packet[i++] = 0;
 
-  HEALTHY_PACKET[i] = checksum(HEALTHY_PACKET + 1, i - 1);
+  packet[i] = checksum(packet + 1, i - 1);
   i++;
 }
 
-int healthy_packet(unsigned char **packet) {
-  *packet = HEALTHY_PACKET;
-  return PACKET_LEN;
+void set_voltage(unsigned char *packet, int voltage) {
+  set_voltage(packet, static_cast<double>(voltage));
 }
 
-void set_voltage(int voltage) { set_voltage((float)voltage); }
-
-void set_voltage(float v) {
+void set_voltage(unsigned char *packet, double v) {
   int voltage = (int)(v * 1000);
   unsigned char low = voltage & 0xff;
   unsigned char high = (voltage >> 8) & 0xff;
 
   int i = 3;
   for (int j = 0; j < 24; j++) {
-    HEALTHY_PACKET[i++] = low;
-    HEALTHY_PACKET[i++] = high;
+    packet[i++] = low;
+    packet[i++] = high;
   }
-  HEALTHY_PACKET[PACKET_LEN - 1] = checksum(HEALTHY_PACKET + 1, PACKET_LEN - 2);
+  packet[PACKET_LEN - 1] = checksum(packet + 1, PACKET_LEN - 2);
 }
 
-void set_voltage(float v, int ind) {
+void set_voltage(unsigned char *packet, double v, int ind) {
   int voltage = (int)(v * 1000);
   unsigned char low = voltage & 0xff;
   unsigned char high = (voltage >> 8) & 0xff;
 
   int i = 3 + 2 * ind;
-  HEALTHY_PACKET[i++] = low;
-  HEALTHY_PACKET[i++] = high;
+  packet[i++] = low;
+  packet[i++] = high;
 
-  HEALTHY_PACKET[PACKET_LEN - 1] = checksum(HEALTHY_PACKET + 1, PACKET_LEN - 2);
+  packet[PACKET_LEN - 1] = checksum(packet + 1, PACKET_LEN - 2);
 }
 
-void set_temperature(int temp, int ind) { set_temperature((float)temp, ind); }
+void set_temperature(unsigned char *packet, int temp, int ind) {
+  set_temperature(packet, static_cast<double>(temp), ind);
+}
 
-void set_temperature(float t, int ind) {
+void set_temperature(unsigned char *packet, double t, int ind) {
   int temp = (int)(t * 1000);
   unsigned char low = temp & 0xff;
   unsigned char high = (temp >> 8) & 0xff;
 
   int i = 3 + 24 * 2 + ind * 2;
-  HEALTHY_PACKET[i++] = low;
-  HEALTHY_PACKET[i++] = high;
-  HEALTHY_PACKET[PACKET_LEN - 1] = checksum(HEALTHY_PACKET + 1, PACKET_LEN - 2);
+  packet[i++] = low;
+  packet[i++] = high;
+  packet[PACKET_LEN - 1] = checksum(packet + 1, PACKET_LEN - 2);
 }

--- a/BatterySpoof/spoof.cpp
+++ b/BatterySpoof/spoof.cpp
@@ -47,18 +47,6 @@ void set_voltage(unsigned char *packet, double v) {
   packet[PACKET_LEN - 1] = checksum(packet + 1, PACKET_LEN - 2);
 }
 
-void set_voltage(unsigned char *packet, double v, int ind) {
-  int voltage = (int)(v * 1000);
-  unsigned char low = voltage & 0xff;
-  unsigned char high = (voltage >> 8) & 0xff;
-
-  int i = 3 + 2 * ind;
-  packet[i++] = low;
-  packet[i++] = high;
-
-  packet[PACKET_LEN - 1] = checksum(packet + 1, PACKET_LEN - 2);
-}
-
 void set_temperature(unsigned char *packet, int temp, int ind) {
   set_temperature(packet, static_cast<double>(temp), ind);
 }

--- a/BatterySpoof/spoof.hpp
+++ b/BatterySpoof/spoof.hpp
@@ -1,13 +1,14 @@
 #ifndef RAV4_SPOOF_HPP
 #define RAV4_SPOOF_HPP
 
-void init_packet();
-int healthy_packet(unsigned char **);
+constexpr int PACKET_LEN = 62;
+
+void init_packet(unsigned char *);
 unsigned char checksum(const unsigned char *arr, int len);
-void set_voltage(int);
-void set_voltage(float);
-void set_voltage(float, int);
-void set_temperature(int, int);
-void set_temperature(float, int);
+void set_voltage(unsigned char *, int);
+void set_voltage(unsigned char *, double);
+void set_voltage(unsigned char *, double, int);
+void set_temperature(unsigned char *, int, int);
+void set_temperature(unsigned char *, double, int);
 
 #endif

--- a/BatterySpoof/spoof.hpp
+++ b/BatterySpoof/spoof.hpp
@@ -7,7 +7,6 @@ void init_packet(unsigned char *);
 unsigned char checksum(const unsigned char *arr, int len);
 void set_voltage(unsigned char *, int);
 void set_voltage(unsigned char *, double);
-void set_voltage(unsigned char *, double, int);
 void set_temperature(unsigned char *, int, int);
 void set_temperature(unsigned char *, double, int);
 

--- a/BatterySpoof/test/test.cpp
+++ b/BatterySpoof/test/test.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 
 #include "../spoof.hpp"
+#include "../time.hpp"
 
 unsigned char PACKET[PACKET_LEN];
 
@@ -83,8 +84,14 @@ void test_set_temperature() {
   assert(0xff == checksum(PACKET, PACKET_LEN));
 }
 
-bool contains(const char *s1, const char *s2) {
-  return strstr(s1, s2) != nullptr;
+void test_time_between() {
+  assert(67 == time_between(100, 167));
+
+  // sanity check that I understand constants and over/underflow
+  unsigned long almost_overflow = -5;
+  assert(almost_overflow == ULONG_MAX - 4);
+
+  assert(6767 == time_between(almost_overflow, 6762));
 }
 
 void run_tests() {
@@ -92,6 +99,7 @@ void run_tests() {
   test_init_packet();
   test_set_voltage();
   test_set_temperature();
+  test_time_between();
 }
 
 int main(int, char **) {

--- a/BatterySpoof/time.cpp
+++ b/BatterySpoof/time.cpp
@@ -1,0 +1,9 @@
+#include "time.hpp"
+
+unsigned long time_between(const unsigned long a, const unsigned long b) {
+  if (b >= a) {
+    return b - a;
+  }
+  // clock overflow?
+  return (ULONG_MAX - a) + b + 1;
+}

--- a/BatterySpoof/time.hpp
+++ b/BatterySpoof/time.hpp
@@ -1,0 +1,8 @@
+#ifndef RAV4_TIME_HPP
+#define RAV4_TIME_HPP
+
+#include <climits>
+
+unsigned long time_between(unsigned long a, unsigned long b);
+
+#endif // RAV4_TIME_HPP

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ifdef DEBUG_LOG
 	extra_compilation_flags += -DDEBUG_LOG
 endif
 
-BatterySpoof/build/$(fqbn_path)/BatterySpoof.ino.elf: BatterySpoof/BatterySpoof.ino BatterySpoof/spoof.hpp BatterySpoof/spoof.cpp BatterySpoof/gauge.hpp BatterySpoof/gauge.cpp BatterySpoof/can.hpp BatterySpoof/can.cpp
+BatterySpoof/build/$(fqbn_path)/BatterySpoof.ino.elf: BatterySpoof/BatterySpoof.ino BatterySpoof/spoof.hpp BatterySpoof/spoof.cpp BatterySpoof/gauge.hpp BatterySpoof/gauge.cpp BatterySpoof/can.hpp BatterySpoof/can.cpp BatterySpoof/time.hpp BatterySpoof/time.cpp
 	arduino-cli compile --fqbn $(fqbn) BatterySpoof --export-binaries --warnings all \
 		--build-property compiler.cpp.extra_flags="$(extra_compilation_flags)"
 
@@ -55,9 +55,9 @@ test: build-test run-test
 .PHONY: build-test
 build-test: BatterySpoof/test/build/test
 
-BatterySpoof/test/build/test: BatterySpoof/test/test.cpp BatterySpoof/spoof.hpp BatterySpoof/spoof.cpp
+BatterySpoof/test/build/test: BatterySpoof/test/test.cpp BatterySpoof/spoof.hpp BatterySpoof/spoof.cpp BatterySpoof/time.hpp BatterySpoof/time.cpp
 	mkdir -p BatterySpoof/test/build
-	$(CXX) $(extra_compilation_flags) -o BatterySpoof/test/build/test BatterySpoof/test/test.cpp BatterySpoof/spoof.cpp
+	$(CXX) $(extra_compilation_flags) -o BatterySpoof/test/build/test BatterySpoof/test/test.cpp BatterySpoof/spoof.cpp BatterySpoof/time.cpp
 
 .PHONY: run-test
 run-test: build-test


### PR DESCRIPTION
This allows us to stop charging automatically after reaching 90% state-of-charge. We implement this in a "defensive" way that requires an up-to-date state-of-charge value read from the CAN bus recently.